### PR TITLE
Add background for jumbotron in dark mode

### DIFF
--- a/assets/css/darkmode.scss
+++ b/assets/css/darkmode.scss
@@ -32,3 +32,7 @@ a {
   background: url('/assets/img/bob_logo_dark.png') center / contain no-repeat !important;
 }
 
+.jumbotron {
+  background-color: #2b2b2b;
+}
+


### PR DESCRIPTION
This would change 
<img width="1277" alt="image" src="https://user-images.githubusercontent.com/3462960/94096927-f4686380-fe42-11ea-91fa-ee23fd7d8d89.png">

to 

<img width="1348" alt="image" src="https://user-images.githubusercontent.com/3462960/94096960-0944f700-fe43-11ea-970f-d6680f572093.png">

I'd leave it open to you to choose a better background color.